### PR TITLE
refactor: Isolate test environment from application

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -36,8 +36,6 @@ INTERNAL_IPS = [
 
 # Application definition
 
-TESTING = "test" in sys.argv or "PYTEST_VERSION" in os.environ
-
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -46,12 +44,9 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "polls",
+    "debug_toolbar",
 ]
 
-if not TESTING:
-    INSTALLED_APPS += [
-        "debug_toolbar",
-    ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -61,11 +56,9 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
-if not TESTING:
-    MIDDLEWARE += [
-        "debug_toolbar.middleware.DebugToolbarMiddleware",
-    ]
+
 
 ROOT_URLCONF = "config.urls"
 
@@ -90,25 +83,16 @@ WSGI_APPLICATION = "config.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-
-if TESTING:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": ":memory:",
-        }
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.getenv("POSTGRES_DB"),
+        "USER": os.getenv("POSTGRES_USER"),
+        "HOST": os.getenv("POSTGRES_HOST"),
+        "PORT": os.getenv("POSTGRES_PORT", "5432"),
+        "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
     }
-else:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.getenv("POSTGRES_DB"),
-            "USER": os.getenv("POSTGRES_USER"),
-            "HOST": os.getenv("POSTGRES_HOST"),
-            "PORT": os.getenv("POSTGRES_PORT", "5432"),
-            "PASSWORD": os.getenv("POSTGRES_PASSWORD"),
-        }
-    }
+}
 
 
 # Password validation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     build:
       context: .
       target: builder
-    env_file: .env
     volumes:
       - ./config:/app/config
       - ./manage.py:/app/manage.py
@@ -25,8 +24,13 @@ services:
       - ./poetry.lock:/app/poetry.lock
       - ./tests:/app/tests
     command: sh -c "poetry run pytest"
+    environment:
+      - POSTGRES_DB=test_polls_db
+      - POSTGRES_USER=test_polls_user
+      - POSTGRES_PASSWORD=test_polls_password
+      - POSTGRES_HOST=db_test
     depends_on:
-      - db
+      - db_test
 
   db:
     image: postgres:15
@@ -36,6 +40,15 @@ services:
       - POSTGRES_DB=polls_db
       - POSTGRES_USER=polls_user
       - POSTGRES_PASSWORD=polls_password
+
+  db_test:
+    image: postgres:15
+    volumes:
+      - postgres_test_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_DB=test_polls_db
+      - POSTGRES_USER=test_polls_user
+      - POSTGRES_PASSWORD=test_polls_password
 
   nginx:
     build: ./nginx
@@ -50,4 +63,5 @@ services:
 
 volumes:
   postgres_data:
+  postgres_test_data:
   static_volume:


### PR DESCRIPTION
Refactor the testing architecture to achieve full production parity.

This change delegates the responsibility of environment setup, including the database, entirely to the infrastructure layer (`docker-compose.yml`).

Key changes:
- Removed the `TESTING` flag and conditional logic from `config/settings.py` to make the application code environment-agnostic.
- Introduced a dedicated `db_test` service in `docker-compose.yml` to run tests against an isolated PostgreSQL database, mirroring the production environment.
- Reconfigured the `test` service to use the new `db_test` database.

This infrastructure-centric approach is superior to application-level environment switching as it ensures tests run in an environment that is as close to production as possible, reducing the risk of environment-specific bugs.