### PR TITLE
This change makes the `web` service's host port configurable in local…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Webサービスのポート番号
+WEB_PORT=8000
+
 # Docker ComposeでNginxが使用するホストIP
 HOST_IP=127.0.0.1
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,7 +15,6 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import RedirectView

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,7 +13,7 @@ services:
       - .:/app
       - venv_volume:/app/.venv
     ports:
-      - "8000:8000"
+      - "${WEB_PORT:-8000}:8000"
     command: poetry run python manage.py runserver 0.0.0.0:8000
 
   test:


### PR DESCRIPTION
… development environments.

Key changes:
- The `web` service's port in `docker-compose.override.yml` was changed from a hardcoded `"8000:8000"` to a flexible `"${WEB_PORT:-8000}:8000"`.
- A `WEB_PORT` variable was added to `.env.example` to document this change and provide a default value.

Architectural Decision:
This change introduces flexibility for local development. Developers can now easily change the host port used by the `web` service by setting a `WEB_PORT` variable in their `.env` file, without modifying version-controlled files. This avoids port conflicts with other services running on their machine. Using a default value (`:-8000`) ensures backward compatibility.

Impact Analysis:
- **CI/CD Pipeline**: No impact, as no pipeline currently exists.
- **Tests**: No impact. The `make test` command uses a separate `test` service that does not depend on the `web` service's port mapping.
- **Production**: No impact. The change is confined to `docker-compose.override.yml`, which is not used in production.

A linting error (unused import) in `config/urls.py` was also fixed during this process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * ホスト側ポートを環境変数 WEB_PORT で上書き可能に（デフォルト8000）。docker-compose.override.yml は ${WEB_PORT:-8000}:8000 を使用。.env.example に WEB_PORT=8000 を追加。

* リファクタ
  * 未使用のインポートを削除（挙動変更なし）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->