### PR TITLE
feat: Make bind address configurable and add docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Webサービスのポート番号
 WEB_PORT=8000
 
+# Webサービスのバインド先 (デフォルトはローカルのみ)
+WEB_BIND_HOST=127.0.0.1
+
 # Docker ComposeでNginxが使用するホストIP
 HOST_IP=127.0.0.1
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ The application will be accessible at `http://127.0.0.1` or `http://localhost`.
 *   **Polls App**: `http://localhost/polls/`
 *   **Admin Site**: `http://localhost/admin/`
 
+## Environment Configuration
+
+You can customize the application's network settings by creating a `.env` file in the project root. This file is automatically used by `docker-compose` when you run `make up`.
+
+-   **`WEB_PORT`**: Sets the port on which the web service will be accessible.
+    -   The default is `8000`.
+    -   Choose a port number between 1024 and 65535.
+    -   If the specified port is already in use, the application will fail to start.
+
+-   **`WEB_BIND_HOST`**: Sets the IP address to which the web service will bind.
+    -   The default is `127.0.0.1` (localhost), which means the service is only accessible from your local machine. This is recommended for development for security reasons.
+    -   To allow access from other devices on your network (e.g., for testing on a mobile device), you can set this to `0.0.0.0`.
+
 ### Testing
 
 To run the test suite, execute the following command. This will start a dedicated test database and run the tests against it.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,7 +13,7 @@ services:
       - .:/app
       - venv_volume:/app/.venv
     ports:
-      - "${WEB_PORT:-8000}:8000"
+      - "${WEB_BIND_HOST:-127.0.0.1}:${WEB_PORT:-8000}:8000"
     command: poetry run python manage.py runserver 0.0.0.0:8000
 
   test:


### PR DESCRIPTION
This commit addresses feedback to improve the security and usability of the development environment.

- Add `WEB_BIND_HOST` to `.env.example`, defaulting to `127.0.0.1` to avoid accidental exposure on the network.
- Update `docker-compose.override.yml` to use `WEB_BIND_HOST` for the port mapping.
- Add a new "Environment Configuration" section to `README.md` to explain how to use `WEB_PORT` and `WEB_BIND_HOST`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * WEB_BIND_HOST 環境変数を追加。WEB_PORT と併用してホスト IP/ポートを指定可能になり、デフォルトでローカルホストのみにバインド。
  * 実行時のポート公開方法を IP:PORT 形式に変更し、外部アクセス可否を制御可能に。

* ドキュメント
  * .env を用いたネットワーク設定手順を追記（WEB_PORT の範囲・競合時の挙動、WEB_BIND_HOST の使用例）。
  * コード品質関連の lint/format 実行方法と Makefile コマンド一覧を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->