### PR TITLE
refactor(e2e): use testcontainers for E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ db-test: ## Run the slower, database-dependent tests locally
 .PHONY: e2e-test
 e2e-test: ## Run end-to-end tests against a live application stack
 	@echo "Running end-to-end tests..."
-	@python -m pytest tests/e2e -v -s
+	@$(PYTHON) -m pytest tests/e2e -v -s
 
 
 .PHONY: build-test

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -5,18 +5,12 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_polls_index_page_loads(page_url: str):
-    """
-    E2E test to ensure the main polls index page loads correctly.
-    """
-    # Arrange
+    """メインの投票インデックスページが正しく読み込まれることを確認するE2Eテスト。"""
     index_url = f"{page_url}polls/"
 
-    # Act
     async with httpx.AsyncClient(timeout=30) as client:
         response = await client.get(index_url)
 
-    # Assert
     assert response.status_code == 200
-    # Check for basic polls page structure (works whether polls exist or not)
     assert "framework?" in response.text or "No polls are available." in response.text
     assert "<title>Polls</title>" in response.text


### PR DESCRIPTION
Replaced the direct `subprocess` calls to `docker compose` with the `testcontainers` library for managing the application stack in end-to-end tests.

- In `tests/e2e/conftest.py`, the `docker_server` fixture has been replaced by `app_container` and `page_url` fixtures that leverage `testcontainers.compose.DockerCompose`. This decouples the test code from the infrastructure management and improves reliability.
- The docstring for the test in `tests/e2e/test_e2e.py` was updated.
- The `Makefile` was modified to ensure the `e2e-test` target uses the python executable from the virtual environment, which is necessary for the tests to find their dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- テスト
  - E2Eテストのコンテナ起動とヘルスチェックを Testcontainers ベースに変更し、起動待機をHTTPヘルスチェックに統一。待機ロジックとURL解決を簡素化して安定性と再現性を向上、テスト記述を整理して可読性を改善。

- チョア
  - e2e実行でプロジェクト仮想環境のPythonを利用するようにし、ローカルとCI間の実行一貫性を向上。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->